### PR TITLE
Aero Glass support for Windows Vista

### DIFF
--- a/browser/themes/windows/browser-aero.css
+++ b/browser/themes/windows/browser-aero.css
@@ -293,7 +293,7 @@
     /* Artificially draw window borders that are covered by lwtheme, see bug 591930.
      * Borders for Vista/7 are below, win10 doesn't need them. */
     #main-window[sizemode="normal"] > #navigator-toolbox:-moz-lwtheme {
-      border-top: 1px solid hsla(240,5%,5%,0.3);
+      border-top: @glassShadowColor@;
     }
   }
 
@@ -308,8 +308,8 @@
     /* Vertical toolbar border */
     #main-window[sizemode=normal] .browser-toolbar:not(.titlebar-color):not(:-moz-lwtheme),
     #main-window[sizemode=normal] .browser-toolbar:-moz-lwtheme {
-      border-left: 1px solid hsla(240,5%,5%,0.3);
-      border-right: 1px solid hsla(240,5%,5%,0.3);
+      border-left: 1px solid @glassShadowColor@;
+      border-right: 1px solid @glassShadowColor@;
       background-clip: padding-box;
     }
 

--- a/browser/themes/windows/browser-aero.css
+++ b/browser/themes/windows/browser-aero.css
@@ -6,7 +6,8 @@
 %define glassActiveBorderColor rgb(37, 44, 51)
 %define glassInactiveBorderColor rgb(102, 102, 102)
 
-@media (-moz-os-version: windows-win7),
+@media (-moz-windows-glass),
+       (-moz-os-version: windows-win7),
        (-moz-os-version: windows-win8) {
   @media (-moz-windows-classic: 0) {
     #main-window[sizemode="normal"] > #navigator-toolbox > #titlebar > #toolbar-menubar:not([autohide="true"]) > #menubar-items,
@@ -14,7 +15,7 @@
       margin-top: 1px;
     }
     /**
-     * Except for Windows 8, Windows 7 Aero and Windows 7 Aero Basic, the
+     * Except for Windows 8, Windows Vista/7 Aero and Aero Basic, the
      * -moz-window-button-box appearance on the .titlebar-buttonbox adds an
      * unwanted margin at the top of the button box.
      *
@@ -39,229 +40,232 @@
 }
 
 @media (-moz-windows-compositor) {
-  @media not (-moz-os-version: windows-win7) {
-    @media not (-moz-os-version: windows-win8) {
-      @media (-moz-windows-default-theme) {
-        :root:not(:-moz-lwtheme) {
-          background-color: hsl(0, 0%, 78%);
+  @media not (-moz-windows-glass) {
+    @media not (-moz-os-version: windows-win7) {
+      @media not (-moz-os-version: windows-win8) {
+        @media (-moz-windows-default-theme) {
+          :root:not(:-moz-lwtheme) {
+            background-color: hsl(0, 0%, 78%);
+          }
+
+          @media (-moz-windows-accent-color-in-titlebar: 0) {
+            :root[sizemode=normal][tabsintitlebar] {
+              border-top: 1px solid rgba(0,0,0,.7);
+            }
+            :root[sizemode=normal][tabsintitlebar][always-use-accent-color-for-window-border]:not(:-moz-window-inactive) {
+              border-top-color: -moz-win-accentcolor;
+            }
+            :root[tabsintitlebar]:not(:-moz-lwtheme) {
+              background-color: hsl(235,33%,19%);
+              color: hsl(240,9%,98%);
+            }
+          }
+
+          @media (-moz-windows-accent-color-in-titlebar) {
+            :root[sizemode=normal][tabsintitlebar] {
+              border-top: 1px solid -moz-win-accentcolor;
+            }
+            :root[tabsintitlebar]:not(:-moz-window-inactive):not(:-moz-lwtheme),
+            :root[tabsintitlebar]:not(:-moz-window-inactive)[lwt-default-theme-in-dark-mode] {
+              background-color: -moz-win-accentcolor;
+              color: -moz-win-accentcolortext;
+            }
+            :root[tabsintitlebar][lwt-default-theme-in-dark-mode] #titlebar {
+              --lwt-toolbarbutton-icon-fill: currentColor;
+              --toolbarbutton-icon-fill-opacity: .7;
+            }
+          }
+
+          :root[sizemode=normal][tabsintitlebar]:-moz-window-inactive {
+            border-top-color: rgba(0,0,0,.3);
+          }
+
+          :root[tabsintitlebar] .tab-label:-moz-window-inactive {
+            /* Calculated to match the opacity change of Windows Explorer
+               titlebar text change for inactive windows. */
+            opacity: .6;
+          }
         }
 
-        @media (-moz-windows-accent-color-in-titlebar: 0) {
-          :root[sizemode=normal][tabsintitlebar] {
-            border-top: 1px solid rgba(0,0,0,.7);
+        @media (-moz-windows-default-theme: 0) {
+          :root[tabsintitlebar] {
+            -moz-appearance: -moz-win-glass;
           }
-          :root[sizemode=normal][tabsintitlebar][always-use-accent-color-for-window-border]:not(:-moz-window-inactive) {
-            border-top-color: -moz-win-accentcolor;
-          }
+
           :root[tabsintitlebar]:not(:-moz-lwtheme) {
-            background-color: hsl(235,33%,19%);
-            color: hsl(240,9%,98%);
+            background-color: transparent;
+          }
+
+          /* On win10, if we don't set this on the entire browser container including
+           * the sidebar, if the sidebar is open the accent color bleeds through in
+           * the titlebar */
+          :root[tabsintitlebar] #browser {
+            -moz-appearance: -moz-win-exclude-glass;
           }
         }
 
-        @media (-moz-windows-accent-color-in-titlebar) {
-          :root[sizemode=normal][tabsintitlebar] {
-            border-top: 1px solid -moz-win-accentcolor;
-          }
-          :root[tabsintitlebar]:not(:-moz-window-inactive):not(:-moz-lwtheme),
-          :root[tabsintitlebar]:not(:-moz-window-inactive)[lwt-default-theme-in-dark-mode] {
-            background-color: -moz-win-accentcolor;
-            color: -moz-win-accentcolortext;
-          }
-          :root[tabsintitlebar][lwt-default-theme-in-dark-mode] #titlebar {
-            --lwt-toolbarbutton-icon-fill: currentColor;
-            --toolbarbutton-icon-fill-opacity: .7;
-          }
-        }
-
-        :root[sizemode=normal][tabsintitlebar]:-moz-window-inactive {
-          border-top-color: rgba(0,0,0,.3);
-        }
-
-        :root[tabsintitlebar] .tab-label:-moz-window-inactive {
-          /* Calculated to match the opacity change of Windows Explorer
-             titlebar text change for inactive windows. */
-          opacity: .6;
-        }
-      }
-
-      @media (-moz-windows-default-theme: 0) {
-        :root[tabsintitlebar] {
-          -moz-appearance: -moz-win-glass;
-        }
-
-        :root[tabsintitlebar]:not(:-moz-lwtheme) {
-          background-color: transparent;
-        }
-
-        /* On win10, if we don't set this on the entire browser container including
-         * the sidebar, if the sidebar is open the accent color bleeds through in
-         * the titlebar */
-        :root[tabsintitlebar] #browser {
-          -moz-appearance: -moz-win-exclude-glass;
-        }
-      }
-
-      .titlebar-buttonbox,
-      .titlebar-button {
-        -moz-appearance: none !important;
-      }
-
-      .titlebar-button {
-        border: none;
-        margin: 0 !important;
-        padding: 8px 17px;
-        -moz-context-properties: stroke;
-        stroke: currentColor;
-      }
-
-      .titlebar-button > .toolbarbutton-icon {
-        width: 12px;
-        height: 12px;
-      }
-
-      .titlebar-min {
-        list-style-image: url(chrome://browser/skin/window-controls/minimize.svg);
-      }
-
-      .titlebar-max {
-        list-style-image: url(chrome://browser/skin/window-controls/maximize.svg);
-      }
-
-      :root[sizemode="maximized"] .titlebar-max {
-        list-style-image: url(chrome://browser/skin/window-controls/restore.svg);
-      }
-
-      .titlebar-close {
-        list-style-image: url(chrome://browser/skin/window-controls/close.svg);
-      }
-
-      :root[lwtheme-image] .titlebar-button {
-        -moz-context-properties: unset;
-      }
-      :root[lwtheme-image] .titlebar-min {
-        list-style-image: url(chrome://browser/skin/window-controls/minimize-themes.svg);
-      }
-      :root[lwtheme-image] .titlebar-max {
-        list-style-image: url(chrome://browser/skin/window-controls/maximize-themes.svg);
-      }
-      :root[lwtheme-image][sizemode="maximized"] .titlebar-max {
-        list-style-image: url(chrome://browser/skin/window-controls/restore-themes.svg);
-      }
-      :root[lwtheme-image] .titlebar-close {
-        list-style-image: url(chrome://browser/skin/window-controls/close-themes.svg);
-      }
-
-      /* the 12px image renders a 10px icon, and the 10px upscaled gets rounded to 12.5, which
-       * rounds up to 13px, which makes the icon one pixel too big on 1.25dppx. Fix: */
-      @media (min-resolution: 1.20dppx) and (max-resolution: 1.45dppx) {
-        .titlebar-button > .toolbarbutton-icon {
-          width: 11.5px;
-          height: 11.5px;
-        }
-      }
-
-      /* 175% dpi should result in the same device pixel sizes as 150% dpi. */
-      @media (min-resolution: 1.70dppx) and (max-resolution: 1.95dppx) {
+        .titlebar-buttonbox,
         .titlebar-button {
-          padding-left: 14.1px;
-          padding-right: 14.1px;
+          -moz-appearance: none !important;
         }
 
-        .titlebar-button > .toolbarbutton-icon {
-          width: 10.8px;
-          height: 10.8px;
-        }
-      }
-
-      /* 225% dpi should result in the same device pixel sizes as 200% dpi. */
-      @media (min-resolution: 2.20dppx) and (max-resolution: 2.45dppx) {
         .titlebar-button {
-          padding-left: 15.3333px;
-          padding-right: 15.3333px;
+          border: none;
+          margin: 0 !important;
+          padding: 8px 17px;
+          -moz-context-properties: stroke;
+          stroke: currentColor;
         }
 
         .titlebar-button > .toolbarbutton-icon {
-          width: 10.8px;
-          height: 10.8px;
-        }
-      }
-
-      /* 275% dpi should result in the same device pixel sizes as 250% dpi. */
-      @media (min-resolution: 2.70dppx) and (max-resolution: 2.95dppx) {
-        /* NB: todo: this should also change padding on the buttons
-         * themselves, but without a device to test this on, it's
-         * impossible to know by how much. */
-        .titlebar-button > .toolbarbutton-icon {
-          width: 10.8px;
-          height: 10.8px;
-        }
-      }
-
-      @media (-moz-windows-default-theme) {
-        #main-menubar > menu[_moz-menuactive="true"] {
-          color: inherit;
-        }
-
-        #main-menubar > menu[_moz-menuactive="true"],
-        .titlebar-button:hover {
-          background-color: hsla(0,0%,0%,.12);
-        }
-        .titlebar-button:hover:active {
-          background-color: hsla(0,0%,0%,.22);
-        }
-
-        #toolbar-menubar[brighttext] > #menubar-items > #main-menubar > menu[_moz-menuactive="true"],
-        toolbar[brighttext] .titlebar-button:not(.titlebar-close):hover {
-          background-color: hsla(0,0%,100%,.22);
-        }
-        toolbar[brighttext] .titlebar-button:not(.titlebar-close):hover:active {
-          background-color: hsla(0,0%,100%,.32);
-        }
-
-        .titlebar-close:hover {
-          stroke: white;
-          background-color: hsl(355,86%,49%);
-        }
-        .titlebar-close:hover:active {
-          background-color: hsl(355,82%,69%);
-        }
-
-        .titlebar-button:not(:hover) > .toolbarbutton-icon:-moz-window-inactive {
-          opacity: 0.5;
-        }
-      }
-
-      @media (-moz-windows-default-theme: 0) {
-        .titlebar-button {
-          background-color: -moz-field;
-          stroke: ButtonText;
-        }
-        .titlebar-button:hover {
-          background-color: Highlight;
-          stroke: HighlightText;
+          width: 12px;
+          height: 12px;
         }
 
         .titlebar-min {
-          list-style-image: url(chrome://browser/skin/window-controls/minimize-highcontrast.svg);
+          list-style-image: url(chrome://browser/skin/window-controls/minimize.svg);
         }
 
         .titlebar-max {
-          list-style-image: url(chrome://browser/skin/window-controls/maximize-highcontrast.svg);
+          list-style-image: url(chrome://browser/skin/window-controls/maximize.svg);
         }
 
         :root[sizemode="maximized"] .titlebar-max {
-          list-style-image: url(chrome://browser/skin/window-controls/restore-highcontrast.svg);
+          list-style-image: url(chrome://browser/skin/window-controls/restore.svg);
         }
 
         .titlebar-close {
-          list-style-image: url(chrome://browser/skin/window-controls/close-highcontrast.svg);
+          list-style-image: url(chrome://browser/skin/window-controls/close.svg);
+        }
+
+        :root[lwtheme-image] .titlebar-button {
+          -moz-context-properties: unset;
+        }
+        :root[lwtheme-image] .titlebar-min {
+          list-style-image: url(chrome://browser/skin/window-controls/minimize-themes.svg);
+        }
+        :root[lwtheme-image] .titlebar-max {
+          list-style-image: url(chrome://browser/skin/window-controls/maximize-themes.svg);
+        }
+        :root[lwtheme-image][sizemode="maximized"] .titlebar-max {
+          list-style-image: url(chrome://browser/skin/window-controls/restore-themes.svg);
+        }
+        :root[lwtheme-image] .titlebar-close {
+          list-style-image: url(chrome://browser/skin/window-controls/close-themes.svg);
+        }
+
+        /* the 12px image renders a 10px icon, and the 10px upscaled gets rounded to 12.5, which
+         * rounds up to 13px, which makes the icon one pixel too big on 1.25dppx. Fix: */
+        @media (min-resolution: 1.20dppx) and (max-resolution: 1.45dppx) {
+          .titlebar-button > .toolbarbutton-icon {
+            width: 11.5px;
+            height: 11.5px;
+          }
+        }
+
+        /* 175% dpi should result in the same device pixel sizes as 150% dpi. */
+        @media (min-resolution: 1.70dppx) and (max-resolution: 1.95dppx) {
+          .titlebar-button {
+            padding-left: 14.1px;
+            padding-right: 14.1px;
+          }
+
+          .titlebar-button > .toolbarbutton-icon {
+            width: 10.8px;
+            height: 10.8px;
+          }
+        }
+
+        /* 225% dpi should result in the same device pixel sizes as 200% dpi. */
+        @media (min-resolution: 2.20dppx) and (max-resolution: 2.45dppx) {
+          .titlebar-button {
+            padding-left: 15.3333px;
+            padding-right: 15.3333px;
+          }
+
+          .titlebar-button > .toolbarbutton-icon {
+            width: 10.8px;
+            height: 10.8px;
+          }
+        }
+
+        /* 275% dpi should result in the same device pixel sizes as 250% dpi. */
+        @media (min-resolution: 2.70dppx) and (max-resolution: 2.95dppx) {
+          /* NB: todo: this should also change padding on the buttons
+           * themselves, but without a device to test this on, it's
+           * impossible to know by how much. */
+          .titlebar-button > .toolbarbutton-icon {
+            width: 10.8px;
+            height: 10.8px;
+          }
+        }
+
+        @media (-moz-windows-default-theme) {
+          #main-menubar > menu[_moz-menuactive="true"] {
+            color: inherit;
+          }
+
+          #main-menubar > menu[_moz-menuactive="true"],
+          .titlebar-button:hover {
+            background-color: hsla(0,0%,0%,.12);
+          }
+          .titlebar-button:hover:active {
+            background-color: hsla(0,0%,0%,.22);
+          }
+
+          #toolbar-menubar[brighttext] > #menubar-items > #main-menubar > menu[_moz-menuactive="true"],
+          toolbar[brighttext] .titlebar-button:not(.titlebar-close):hover {
+            background-color: hsla(0,0%,100%,.22);
+          }
+          toolbar[brighttext] .titlebar-button:not(.titlebar-close):hover:active {
+            background-color: hsla(0,0%,100%,.32);
+          }
+
+          .titlebar-close:hover {
+            stroke: white;
+            background-color: hsl(355,86%,49%);
+          }
+          .titlebar-close:hover:active {
+            background-color: hsl(355,82%,69%);
+          }
+
+          .titlebar-button:not(:hover) > .toolbarbutton-icon:-moz-window-inactive {
+            opacity: 0.5;
+          }
+        }
+
+        @media (-moz-windows-default-theme: 0) {
+          .titlebar-button {
+            background-color: -moz-field;
+            stroke: ButtonText;
+          }
+          .titlebar-button:hover {
+            background-color: Highlight;
+            stroke: HighlightText;
+          }
+
+          .titlebar-min {
+            list-style-image: url(chrome://browser/skin/window-controls/minimize-highcontrast.svg);
+          }
+
+          .titlebar-max {
+            list-style-image: url(chrome://browser/skin/window-controls/maximize-highcontrast.svg);
+          }
+
+          :root[sizemode="maximized"] .titlebar-max {
+            list-style-image: url(chrome://browser/skin/window-controls/restore-highcontrast.svg);
+          }
+
+          .titlebar-close {
+            list-style-image: url(chrome://browser/skin/window-controls/close-highcontrast.svg);
+          }
         }
       }
     }
   }
 
-  @media (-moz-os-version: windows-win7),
+  @media (-moz-windows-glass),
+         (-moz-os-version: windows-win7),
          (-moz-os-version: windows-win8) {
     :root {
       background-color: transparent;
@@ -278,7 +282,7 @@
     }
 
     /* The borders on the glass frame are ours, and inside #browser, and on
-     * win7 we want to make sure they are "glassy", so we can't use #browser
+     * Vista/7 we want to make sure they are "glassy", so we can't use #browser
      * as the exclude-glass container. We use #appcontent instead. */
     #appcontent {
       -moz-appearance: -moz-win-exclude-glass;
@@ -287,9 +291,9 @@
 
   @media (-moz-os-version: windows-win8) {
     /* Artificially draw window borders that are covered by lwtheme, see bug 591930.
-     * Borders for win7 are below, win10 doesn't need them. */
+     * Borders for Vista/7 are below, win10 doesn't need them. */
     #main-window[sizemode="normal"] > #navigator-toolbox:-moz-lwtheme {
-      border-top: 1px solid @glassShadowColor@;
+      border-top: 1px solid hsla(240,5%,5%,0.3);
     }
   }
 
@@ -297,14 +301,15 @@
     color: white;
   }
 
-  /* Show borders on Win 7 & 8, but not on 10 and later: */
-  @media (-moz-os-version: windows-win7),
+  /* Show borders on Vista, 7 & 8, but not on 10 and later: */
+  @media (-moz-windows-glass),
+         (-moz-os-version: windows-win7),
          (-moz-os-version: windows-win8) {
     /* Vertical toolbar border */
     #main-window[sizemode=normal] .browser-toolbar:not(.titlebar-color):not(:-moz-lwtheme),
     #main-window[sizemode=normal] .browser-toolbar:-moz-lwtheme {
-      border-left: 1px solid @glassShadowColor@;
-      border-right: 1px solid @glassShadowColor@;
+      border-left: 1px solid hsla(240,5%,5%,0.3);
+      border-right: 1px solid hsla(240,5%,5%,0.3);
       background-clip: padding-box;
     }
 

--- a/browser/themes/windows/browser-aero.css
+++ b/browser/themes/windows/browser-aero.css
@@ -293,7 +293,7 @@
     /* Artificially draw window borders that are covered by lwtheme, see bug 591930.
      * Borders for Vista/7 are below, win10 doesn't need them. */
     #main-window[sizemode="normal"] > #navigator-toolbox:-moz-lwtheme {
-      border-top: @glassShadowColor@;
+      border-top: 1px solid @glassShadowColor@;
     }
   }
 

--- a/browser/themes/windows/browser.css
+++ b/browser/themes/windows/browser.css
@@ -90,26 +90,30 @@
 }
 
 /* Use a different color only on Windows 8 and higher in inactive windows.
- * On Win 7, the menubar fog disappears for inactive windows, and renders gray
- * illegible.
+ * On Win Vista and 7, the menubar fog disappears for inactive windows, 
+ * and renders grey illegible.
  */
 @media (-moz-windows-default-theme) {
-  @media not (-moz-os-version: windows-win7) {
+  @media not (-moz-windows-glass) {
+      @media not (-moz-os-version: windows-win7) {
     #toolbar-menubar:not(:-moz-lwtheme):-moz-window-inactive {
       color: ThreeDShadow;
+      }
     }
   }
 }
 
-@media not (-moz-os-version: windows-win7) {
-  @media not (-moz-os-version: windows-win8) {
-    /* On Windows 10, when temporarily showing the menu bar, make it at least as
-     * tall as the tab bar such that the window controls don't appear to move up. */
-    :root[tabsintitlebar] #toolbar-menubar[autohide="true"] {
-      height: calc(var(--tab-min-height) - var(--tabs-navbar-shadow-size));
-    }
-    :root[tabsintitlebar][sizemode="normal"] #toolbar-menubar[autohide="true"] {
-      height: calc(var(--tab-min-height) + var(--space-above-tabbar) - var(--tabs-navbar-shadow-size));
+@media not (-moz-windows-glass) {
+  @media not (-moz-os-version: windows-win7) {
+    @media not (-moz-os-version: windows-win8) {
+      /* On Windows 10, when temporarily showing the menu bar, make it at least as
+       * tall as the tab bar such that the window controls don't appear to move up. */
+      :root[tabsintitlebar] #toolbar-menubar[autohide="true"] {
+        height: calc(var(--tab-min-height) - var(--tabs-navbar-shadow-size));
+      }
+      :root[tabsintitlebar][sizemode="normal"] #toolbar-menubar[autohide="true"] {
+        height: calc(var(--tab-min-height) + var(--space-above-tabbar) - var(--tabs-navbar-shadow-size));
+      }
     }
   }
 }
@@ -119,8 +123,9 @@
   padding-top: var(--space-above-tabbar);
 }
 
-/* Add 4px extra margin on top of the tabs toolbar on Windows 7. */
-@media (-moz-os-version: windows-win7) {
+/* Add 4px extra margin on top of the tabs toolbar on Windows Vista and 7. */
+@media (-moz-windows-glass), 
+       (-moz-os-version: windows-win7) {
   :root[sizemode="normal"][chromehidden~="menubar"] #TabsToolbar > .toolbar-items,
   :root[sizemode="normal"] #toolbar-menubar[autohide="true"][inactive] + #TabsToolbar > .toolbar-items {
     padding-top: calc(var(--space-above-tabbar) + 4px);
@@ -140,13 +145,14 @@
 }
 
 /*
- * Windows 7 draws the chrome background color as the tab background
- * instead of in the tabs toolbar.
+ * Windows Vista and 7 draw the chrome background color as
+ * the tab background instead of in the tabs toolbar.
  */
-@media (-moz-os-version: windows-win7) {
+@media (-moz-windows-glass), 
+       (-moz-os-version: windows-win7) {
   @media (-moz-windows-default-theme) {
     #navigator-toolbox:not(:-moz-lwtheme) {
-      --tabs-border-color: @glassShadowColor@;
+      --tabs-border-color: hsla(240,5%,5%,0.3);
     }
 
     #TabsToolbar:not(:-moz-lwtheme) {
@@ -333,7 +339,7 @@
    * click and hover mouse events to work properly for the button in the restored
    * window state. Otherwise, elements in the navigator-toolbox, like the menubar,
    * can swallow those events. It will also place the buttons above the fog on
-   * Windows 7 with Aero Glass.
+   * Windows Vista and 7 with Aero Glass.
    */
   z-index: 1;
 }
@@ -342,7 +348,8 @@
   -moz-box-align: stretch;
 }
 
-@media (-moz-os-version: windows-win7),
+@media (-moz-windows-glass),
+       (-moz-os-version: windows-win7),
        (-moz-os-version: windows-win8) {
   /* Preserve window control buttons position at the top of the button box. */
   .titlebar-buttonbox-container {
@@ -464,7 +471,8 @@ menuitem.bookmark-item {
   background-color: hsl(355, 82%, 69%);
 }
 
-@media (-moz-os-version: windows-win7) {
+@media (-moz-windows-glass),
+       (-moz-os-version: windows-win7) {
   #window-controls {
     -moz-box-align: start;
     margin-inline-start: 4px;
@@ -986,7 +994,8 @@ panel[touchmode] .PanelUI-subView #appMenu-zoom-controls > .subviewbutton-iconic
   overflow: hidden;
 }
 
-@media (-moz-os-version: windows-win7) {
+@media (-moz-windows-glass),
+       (-moz-os-version: windows-win7) {
   .cui-widget-panelview[id^=PanelUI-webext-] {
     border-radius: 4px;
   }

--- a/browser/themes/windows/browser.css
+++ b/browser/themes/windows/browser.css
@@ -152,7 +152,7 @@
        (-moz-os-version: windows-win7) {
   @media (-moz-windows-default-theme) {
     #navigator-toolbox:not(:-moz-lwtheme) {
-      --tabs-border-color: hsla(240,5%,5%,0.3);
+      --tabs-border-color: @glassShadowColor@;
     }
 
     #TabsToolbar:not(:-moz-lwtheme) {

--- a/browser/themes/windows/compacttheme.css
+++ b/browser/themes/windows/compacttheme.css
@@ -6,7 +6,7 @@
 
 /* The window background is white due to no accentcolor in the lightweight
    theme. It can't be changed to transparent when there is no compositor
-   (Win 7 in classic / basic theme), or else dragging and focus become
+   (Vista/7 in classic / basic theme), or else dragging and focus become
    broken. So instead just show the normal titlebar in that case, and override
    the window color as transparent when the compositor is available. */
 @media (-moz-windows-compositor: 0) {
@@ -26,7 +26,8 @@
   }
 }
 
-@media (-moz-os-version: windows-win7) {
+@media (-moz-windows-glass),
+       (-moz-os-version: windows-win7) {
   @media (-moz-windows-default-theme) {
     /* Always show light toolbar elements on aero surface. */
     #TabsToolbar {
@@ -63,7 +64,8 @@
   }
 }
 
-@media (-moz-os-version: windows-win7),
+@media (-moz-windows-glass),
+       (-moz-os-version: windows-win7),
        (-moz-os-version: windows-win8) {
   @media (-moz-windows-compositor) {
     #main-window {
@@ -109,7 +111,7 @@
     display: none !important;
   }
 
-  /* Use proper menu text styling in Win7 classic mode (copied from browser.css) */
+  /* Use proper menu text styling in Vista/7 classic mode (copied from browser.css) */
   @media (-moz-windows-compositor: 0),
          (-moz-windows-default-theme: 0) {
     :root[tabsintitlebar]:not([inFullscreen]) {

--- a/browser/themes/windows/customizableui/panelUI.css
+++ b/browser/themes/windows/customizableui/panelUI.css
@@ -24,8 +24,9 @@
   margin-top: -4px;
 }
 
-/* Add border-radius on Windows 7 */
-@media (-moz-os-version: windows-win7) {
+/* Add border-radius on Windows Vista/7 */
+@media (-moz-windows-glass),
+       (-moz-os-version: windows-win7) {
   #BMB_bookmarksPopup menupopup[placespopup=true] > hbox {
     border-radius: 3.5px;
   }

--- a/browser/themes/windows/places/organizer.css
+++ b/browser/themes/windows/places/organizer.css
@@ -140,7 +140,8 @@
     position: relative;
   }
 
-  @media (-moz-os-version: windows-win7) {
+  @media (-moz-windows-glass),
+         (-moz-os-version: windows-win7) {
     #detailsDeck {
       border-top-color: #A9B7C9;
     }


### PR DESCRIPTION
Use Win7-based style if `-moz-windows-glass` is triggered (only works if Aero Glass is enabled)

See #58 for more info!

![изображение](https://user-images.githubusercontent.com/71165491/166903857-23dabba1-23ca-401f-b7a6-7d74a9b90529.png)
