### PR TITLE
Fix for title bar button height to make them square on Windows XP

### DIFF
--- a/browser/base/content/browser.css
+++ b/browser/base/content/browser.css
@@ -325,6 +325,17 @@ window:not([chromehidden~="toolbar"]) #nav-bar[nonemptyoverflow] > .overflow-but
   position: relative;
 }
 
+/* Adjusts titlebar button height to make them square on Windows XP  */
+:root[tabsintitlebar] .titlebar-buttonbox-container {
+  max-height:15px !important;
+  }
+  
+ :root[tabsintitlebar] .titlebar-color {   
+  max-height: var(--tab-min-height) !important;
+  }
+ 
+
+
 #personal-bookmarks {
   -moz-window-dragging: inherit;
 }

--- a/browser/base/content/browser.css
+++ b/browser/base/content/browser.css
@@ -333,7 +333,11 @@ window:not([chromehidden~="toolbar"]) #nav-bar[nonemptyoverflow] > .overflow-but
  :root[tabsintitlebar] .titlebar-color {   
   max-height: var(--tab-min-height) !important;
   }
- 
+
+   :root[tabsintitlebar]:not([inFullscreen="true"]):not([sizemode="maximized"]) .titlebar-buttonbox-container { /* Adjusts Buttons when windowed */
+padding-top: 4px !important;
+}
+
 
 
 #personal-bookmarks {

--- a/browser/base/content/browser.css
+++ b/browser/base/content/browser.css
@@ -334,8 +334,10 @@ window:not([chromehidden~="toolbar"]) #nav-bar[nonemptyoverflow] > .overflow-but
   max-height: var(--tab-min-height) !important;
   }
 
-   :root[tabsintitlebar]:not([inFullscreen="true"]):not([sizemode="maximized"]) .titlebar-buttonbox-container { /* Adjusts Buttons when windowed */
+@media not (-moz-windows-classic) {
+  :root[tabsintitlebar]:not([inFullscreen="true"]):not([sizemode="maximized"]) .titlebar-buttonbox-container {
 padding-top: 4px !important;
+}
 }
 
 


### PR DESCRIPTION
Hi @Feodor2,
I've just registered on Github, but i follow your browser projects for about 3-4 years, and want to say that your browser has been very useful on Windows XP for a site that wasn't working on any other browser. So thank you for that :smiley: 

After some days of searching how to fix this little design with my limited skills in CSS, i've now found how to fix the title bar buttons in Windows XP to make them square. (Works with Windows Classic theme too).
It's far from being an "high priority", but it's a little design thing that could make the browser visually more accurate.

Hoping you will like it !

![MypalWinXPbefore](https://user-images.githubusercontent.com/112265122/187039520-e40ffa48-2673-4cd0-b469-59e0c88fa3fc.png)
![MypalWinXPafter](https://user-images.githubusercontent.com/112265122/187039551-2f076dc6-4807-460f-912f-e138d7f9a8dc.png)

