### PR TITLE
Migrate #63 to new OS @medias + Fix XP title buttons

### DIFF
--- a/browser/themes/windows/browser-aero.css
+++ b/browser/themes/windows/browser-aero.css
@@ -6,7 +6,7 @@
 %define glassActiveBorderColor rgb(37, 44, 51)
 %define glassInactiveBorderColor rgb(102, 102, 102)
 
-@media (-moz-windows-glass),
+@media (-moz-os-version: windows-vista),
        (-moz-os-version: windows-win7),
        (-moz-os-version: windows-win8) {
   @media (-moz-windows-classic: 0) {
@@ -40,7 +40,7 @@
 }
 
 @media (-moz-windows-compositor) {
-  @media not (-moz-windows-glass) {
+  @media not (-moz-os-version: windows-vista) {
     @media not (-moz-os-version: windows-win7) {
       @media not (-moz-os-version: windows-win8) {
         @media (-moz-windows-default-theme) {
@@ -264,7 +264,7 @@
     }
   }
 
-  @media (-moz-windows-glass),
+  @media (-moz-os-version: windows-vista),
          (-moz-os-version: windows-win7),
          (-moz-os-version: windows-win8) {
     :root {
@@ -302,7 +302,7 @@
   }
 
   /* Show borders on Vista, 7 & 8, but not on 10 and later: */
-  @media (-moz-windows-glass),
+  @media (-moz-os-version: windows-vista),
          (-moz-os-version: windows-win7),
          (-moz-os-version: windows-win8) {
     /* Vertical toolbar border */

--- a/browser/themes/windows/browser.css
+++ b/browser/themes/windows/browser.css
@@ -94,7 +94,7 @@
  * and renders grey illegible.
  */
 @media (-moz-windows-default-theme) {
-  @media not (-moz-windows-glass) {
+  @media not (-moz-os-version: windows-vista) {
       @media not (-moz-os-version: windows-win7) {
     #toolbar-menubar:not(:-moz-lwtheme):-moz-window-inactive {
       color: ThreeDShadow;
@@ -103,7 +103,7 @@
   }
 }
 
-@media not (-moz-windows-glass) {
+@media not (-moz-os-version: windows-vista) {
   @media not (-moz-os-version: windows-win7) {
     @media not (-moz-os-version: windows-win8) {
       /* On Windows 10, when temporarily showing the menu bar, make it at least as
@@ -124,7 +124,7 @@
 }
 
 /* Add 4px extra margin on top of the tabs toolbar on Windows Vista and 7. */
-@media (-moz-windows-glass), 
+@media (-moz-os-version: windows-vista), 
        (-moz-os-version: windows-win7) {
   :root[sizemode="normal"][chromehidden~="menubar"] #TabsToolbar > .toolbar-items,
   :root[sizemode="normal"] #toolbar-menubar[autohide="true"][inactive] + #TabsToolbar > .toolbar-items {
@@ -148,7 +148,7 @@
  * Windows Vista and 7 draw the chrome background color as
  * the tab background instead of in the tabs toolbar.
  */
-@media (-moz-windows-glass), 
+@media (-moz-os-version: windows-vista), 
        (-moz-os-version: windows-win7) {
   @media (-moz-windows-default-theme) {
     #navigator-toolbox:not(:-moz-lwtheme) {
@@ -348,12 +348,23 @@
   -moz-box-align: stretch;
 }
 
-@media (-moz-windows-glass),
+@media (-moz-os-version: windows-xp),
+       (-moz-os-version: windows-vista),
        (-moz-os-version: windows-win7),
        (-moz-os-version: windows-win8) {
   /* Preserve window control buttons position at the top of the button box. */
   .titlebar-buttonbox-container {
     -moz-box-align: start;
+  }
+}
+
+/* add extra margin for unmaximized windows
+   on Win XP Luna themes to look consistent */
+@media not (-moz-windows-classic) {
+  @media (-moz-os-version: windows-xp) {
+    :root[tabsintitlebar]:not([sizemode="maximized"]) .titlebar-buttonbox-container {
+      margin-top: 4px;
+    }
   }
 }
 
@@ -471,7 +482,8 @@ menuitem.bookmark-item {
   background-color: hsl(355, 82%, 69%);
 }
 
-@media (-moz-windows-glass),
+@media (-moz-os-version: windows-xp),
+       (-moz-os-version: windows-vista),
        (-moz-os-version: windows-win7) {
   #window-controls {
     -moz-box-align: start;
@@ -994,7 +1006,7 @@ panel[touchmode] .PanelUI-subView #appMenu-zoom-controls > .subviewbutton-iconic
   overflow: hidden;
 }
 
-@media (-moz-windows-glass),
+@media (-moz-os-version: windows-vista),
        (-moz-os-version: windows-win7) {
   .cui-widget-panelview[id^=PanelUI-webext-] {
     border-radius: 4px;

--- a/browser/themes/windows/compacttheme.css
+++ b/browser/themes/windows/compacttheme.css
@@ -64,7 +64,7 @@
   }
 }
 
-@media (-moz-windows-glass),
+@media (-moz-os-version: windows-vista),
        (-moz-os-version: windows-win7),
        (-moz-os-version: windows-win8) {
   @media (-moz-windows-compositor) {

--- a/browser/themes/windows/customizableui/panelUI.css
+++ b/browser/themes/windows/customizableui/panelUI.css
@@ -25,7 +25,7 @@
 }
 
 /* Add border-radius on Windows Vista/7 */
-@media (-moz-windows-glass),
+@media (-moz-os-version: windows-vista),
        (-moz-os-version: windows-win7) {
   #BMB_bookmarksPopup menupopup[placespopup=true] > hbox {
     border-radius: 3.5px;

--- a/browser/themes/windows/places/organizer.css
+++ b/browser/themes/windows/places/organizer.css
@@ -140,7 +140,7 @@
     position: relative;
   }
 
-  @media (-moz-windows-glass),
+  @media (-moz-os-version: windows-vista),
          (-moz-os-version: windows-win7) {
     #detailsDeck {
       border-top-color: #A9B7C9;


### PR DESCRIPTION
![изображение](https://github.com/Feodor2/Mypal68/assets/71165491/146cf654-001f-4897-8be4-b3c778172c0e)

Closes #147 and refines changed from #63 to use new @moz-os-version values, which also fixes titlebar buttons appearance in Vista Aero Basic mode:

![изображение](https://github.com/Feodor2/Mypal68/assets/71165491/0393fe57-e855-4ddb-8c82-0821ddc15dff)

As for #190, I'm not sure what causes it but I think it may be related. @MWF2, can you check it please?

P.s. Tested on XP, Vista and 7. Additional testing is very welcomed.