### PR TITLE
Modify imagebase of xul.dll to save memory in XP32 multi-process mode

### DIFF
--- a/toolkit/library/build/moz.build
+++ b/toolkit/library/build/moz.build
@@ -12,6 +12,9 @@ USE_LIBS += ['gkrust']
 
 Libxul('xul-real')
 
+if CONFIG['CPU_ARCH'] == 'x86' and CONFIG['CC_TYPE'] == 'clang-cl' and CONFIG['OS_ARCH'] == 'WINNT':
+    LDFLAGS += ['-BASE:0x22000000']
+
 if CONFIG['COMPILE_ENVIRONMENT']:
     if CONFIG['MOZ_WIDGET_TOOLKIT'] in ('cocoa', 'uikit'):
         full_libname = SHARED_LIBRARY_NAME


### PR DESCRIPTION
It could save a little memory at no cost.

before
![before](https://github.com/user-attachments/assets/a176fefa-851d-45be-9829-bdac695a4cab)

after
![after](https://github.com/user-attachments/assets/df2e3b5a-51f4-413c-8cb2-9d3162cfa44d)