### PR TITLE
Fix Flash plugin crashes

### DIFF
--- a/dom/plugins/ipc/PluginModuleChild.cpp
+++ b/dom/plugins/ipc/PluginModuleChild.cpp
@@ -189,7 +189,7 @@ mozilla::ipc::IPCResult PluginModuleChild::RecvInitProfiler(
 mozilla::ipc::IPCResult PluginModuleChild::RecvDisableFlashProtectedMode() {
   MOZ_ASSERT(mIsChrome);
 #ifdef XP_WIN
-  FunctionHook::HookProtectedMode();
+  //FunctionHook::HookProtectedMode();
 #else
   MOZ_ASSERT(false, "Should not be called");
 #endif


### PR DESCRIPTION
NPSWF32_.NP_Initialize --> ADVAPI32.CryptAcquireContextW --> XUL.CreateFileWHookFn (not implemented)
so just disable the kernel32 hook function
