### PR TITLE
Fix for saving History records as bookmarks

### DIFF
--- a/browser/components/places/content/controller.js
+++ b/browser/components/places/content/controller.js
@@ -203,8 +203,9 @@ PlacesController.prototype = {
         );
       }
       case "placesCmd_createBookmark":
-        var node = this._view.selectedNode;
-        return node && PlacesUtils.nodeIsURI(node) && node.itemId == -1;
+//        var nodes = this._view.selectedNodes;
+//        return nodes && nodes.every(node => PlacesUtils.nodeIsURI(node) && node.itemId == -1);
+        return true;
       default:
         return false;
     }
@@ -286,17 +287,23 @@ PlacesController.prototype = {
         this.sortFolderByName().catch(Cu.reportError);
         break;
       case "placesCmd_createBookmark":
-        let node = this._view.selectedNode;
-        PlacesUIUtils.showBookmarkDialog(
-          {
-            action: "add",
-            type: "bookmark",
-            hiddenRows: ["keyword", "location"],
-            uri: Services.io.newURI(node.uri),
-            title: node.title,
-          },
-          window.top
-        );
+        let nodes = this._view.selectedNodes
+                              .map(function (node) {
+                                     return { title: node.title,
+                                              uri: Services.io.newURI(node.uri)
+                                            };
+                                   });
+        let dialogInfo = { action: "add" };
+        if (nodes.length == 1) {
+          dialogInfo.type = "bookmark";
+          dialogInfo.title = nodes[0].title;
+          dialogInfo.uri = nodes[0].uri;
+          dialogInfo.hiddenRows = ["keyword", "location"];
+        } else {
+          dialogInfo.type = "folder";
+          dialogInfo.URIList = nodes;
+        }
+        PlacesUIUtils.showBookmarkDialog(dialogInfo, window.top);
         break;
     }
   },


### PR DESCRIPTION
Saving History records as bookmarks does not work if more then one record is selected.